### PR TITLE
Implement UART for sercom

### DIFF
--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -30,6 +30,13 @@ path = "../atsamd21e18a"
 version = "~0.2"
 optional = true
 
+[dev-dependencies]
+panic-abort = "~0.1"
+panic-semihosting = "~0.1"
+cortex-m-semihosting = "~0.2"
+cortex-m-rtfm = "~0.3"
+sx1509 = "~0.2"
+
 [features]
 # We default to picking one of the target mcus so that a `cargo build` or
 # `cargo package` run for this crate will succeed.  Without this we won't

--- a/hal/src/sercom/mod.rs
+++ b/hal/src/sercom/mod.rs
@@ -11,7 +11,9 @@
 mod i2c;
 mod pads;
 mod spi;
+mod uart;
 
 pub use self::i2c::*;
 pub use self::pads::*;
 pub use self::spi::*;
+pub use self::uart::*;

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -1,6 +1,8 @@
-use atsamd21g18a::{NVIC, PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
-use atsamd21g18a::interrupt::Interrupt;
-use atsamd21g18a::sercom0::USART;
+use target_device::{NVIC, PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
+#[cfg(feature = "samd21g18a")]
+use target_device::{SERCOM4, SERCOM5};
+use target_device::interrupt::Interrupt;
+use target_device::sercom0::USART;
 use clock;
 use hal::blocking::serial::write::Default;
 use hal::serial::{Read, Write};

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -1,9 +1,10 @@
 use clock;
 use hal::blocking::serial::write::Default;
-use hal::serial::Write;
+use hal::serial::{Write, Read};
 use nb;
 use sercom::pads::*;
 use atsamd21g18a::{PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3, NVIC};
+use atsamd21g18a::sercom0::USART;
 use atsamd21g18a::interrupt::Interrupt;
 use time::Hertz;
 
@@ -13,6 +14,8 @@ pub struct Uart {
     tx: Sercom0Pad2,
     sercom: SERCOM0,
 }
+
+const SHIFT: u8 = 32;
 
 impl Uart {
     pub fn new<F: Into<Hertz>>(
@@ -42,7 +45,8 @@ impl Uart {
                 w.rxpo().bits(0x03); // Uses pad 3 for rx
                 w.txpo().bits(0x01); // Uses pad 2 for tx (and pad 3 for xck)
 
-                w.sampr().bits(0); // 16x oversample
+                w.form().bits(0x00);
+                w.sampr().bits(0x00); // 16x oversample fractional
                 w.runstdby().set_bit(); // Run in standby
                 w.form().bits(0); // 0 is no parity bits
 
@@ -50,11 +54,21 @@ impl Uart {
             });
 
             // Calculate value for BAUD register
-            let sample_rate: u32 = 16;
-            let fref = clock.freq();
+            let sample_rate: u8 = 16;
+            let fref = clock.freq().0;
+
+//            let mul_ratio = (fref.0 * 1000) / (freq.into().0 * 16);
+//
+//            let baud = mul_ratio / 1000;
+//            let fp = ((mul_ratio - (baud*1000))*8)/1000;
+//
+//            sercom.usart.baud.baud_frac_mode.modify(|_, w| {
+//                w.baud().bits(baud as u16);
+//                w.fp().bits(fp as u8)
+//            });
 
             // Asynchronous arithmetic mode (Table 24-2 in datasheet)
-            let baud = 65536 * (1 - (sample_rate * (freq.into().0/ fref.0))) as u16;
+            let baud = Self::calulate_baud_value(freq.into().0, fref, sample_rate);
 
             sercom.usart.baud.baud.modify(|_, w| {
                 w.baud().bits(baud)
@@ -74,6 +88,7 @@ impl Uart {
             sercom.usart.intenset.modify(|_, w| {
                 w.rxc().set_bit()
                 //w.txc().set_bit()
+                //w.dre().set_bit()
             });
 
             sercom.usart.ctrla.modify(|_, w| w.enable().set_bit());
@@ -88,12 +103,37 @@ impl Uart {
         }
     }
 
+    pub fn calulate_baud_value(baudrate: u32, clk_freq: u32, n_samples: u8) -> u16 {
+        let mut ratio: u64 = 0;
+        let mut scale: u64 = 0;
+        let mut baud_calculated: u64 = 0;
+        let mut temp1: u64 = 0;
+
+        temp1 = ((n_samples as u64 * baudrate as u64) << 32);
+        ratio = temp1 / clk_freq as u64;
+        //ratio = long_division(temp1, perip);
+        scale = (1u64 << SHIFT) - ratio;
+        baud_calculated = (65536 * scale) >> SHIFT;
+
+        return baud_calculated as u16;
+    }
+
     pub fn enable_tx_interrupt(&mut self) {
         unsafe {
             self.sercom.usart.intenset.write(|w| {
                 w.txc().set_bit()
             });
         }
+    }
+
+    fn usart(&self) -> &USART {
+        unsafe {
+            return &self.sercom.usart
+        }
+    }
+
+    fn dre(&self) -> bool {
+        self.usart().intflag.read().dre().bit_is_set()
     }
 }
 
@@ -102,9 +142,7 @@ impl Write<u8> for Uart {
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         unsafe {
-            let ready = self.sercom.usart.intflag.read().dre().bit_is_set();
-
-            if !ready {
+            if !self.dre() {
                 return Err(nb::Error::WouldBlock);
             }
 
@@ -117,7 +155,30 @@ impl Write<u8> for Uart {
     }
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        unimplemented!()
+        // simply await DRE empty
+        let ready = self.usart().intflag.read().dre().bit_is_set();
+
+        if !self.dre() {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        Ok(())
+    }
+}
+
+impl Read<u8> for Uart {
+    type Error = ();
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        let has_data = self.usart().intflag.read().rxc().bit_is_set();
+
+        if !has_data {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        let data = self.usart().data.read().bits();
+
+        Ok(data as u8)
     }
 }
 

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -1,0 +1,123 @@
+use clock;
+use hal::blocking::serial::write::Default;
+use hal::serial::Write;
+use nb;
+use sercom::pads::*;
+use target_device::{PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
+use time::Hertz;
+
+
+pub struct Uart {
+    rx: Sercom0Pad2,
+    tx: Sercom0Pad3,
+    sercom: SERCOM0,
+}
+
+impl Uart {
+    pub fn new<F: Into<Hertz>>(
+        clock: &clock::Sercom0CoreClock,
+        freq: F,
+        sercom: SERCOM0,
+        pm: &mut PM,
+        tx: Sercom0Pad3,
+        rx: Sercom0Pad2,
+    ) -> Uart {
+        pm.apbcmask.modify(|_, w| w.sercom0_().set_bit());
+
+        // Lots of union fields which require unsafe access
+        unsafe {
+            sercom.usart.ctrla.write(|w| w.swrst().set_bit());
+            while sercom.usart.syncbusy.read().swrst().bit_is_set()
+                || sercom.usart.ctrla.read().swrst().bit_is_set() {
+                // wait for sync of CTRLA.SWRST
+            }
+
+            // Set mode to USART with internal clock
+            sercom.usart.ctrla.write(|w| w.mode().usart_int_clk());
+
+            // Unsafe b/c of direct call to bits on rxpo/txpo
+            sercom.usart.ctrla.write(|w| {
+                w.cmode().clear_bit(); // 0 means async
+                w.rxpo().bits(2);
+                w.txpo().bits(3);
+
+                w.dord().set_bit();
+                w.form().bits(0) // 0 is standard USART
+            });
+
+            sercom.usart.ctrlb.write(|w| {
+                w.chsize().bits(0x0); // Character size 0 is 8 bits see Table 25-12 in datasheet
+                w.sbmode().clear_bit() // 0 is one stop bit see sec 25.8.2
+            });
+
+            // Calculate value for BAUD register
+            let sample_rate: u32 = 16;
+            let fref = clock.freq();
+
+            // Asynchronous fractional mode (Table 24-2 in datasheet)
+            //   BAUD = fref / (sampleRateValue * fbaud)
+            // (multiply by 8, to calculate fractional piece)
+            let baud_times8 = (fref.0 * 8) / (sample_rate * freq.into().0);
+
+            sercom.usart.baud.baud_fracfp_mode.write(|w| {
+                w.fp().bits((baud_times8 % 8) as u8);
+                w.baud().bits((baud_times8 / 8) as u16)
+            });
+
+            sercom.usart.ctrlb.write(|w| {
+                w.txen().set_bit()
+            });
+            // wait for sync of CTRLB
+            while sercom.usart.syncbusy.read().ctrlb().bit_is_set() {}
+
+            sercom.usart.ctrlb.write(|w| {
+                w.rxen().set_bit()
+            });
+
+            // wait for sync of CTRLB
+            while sercom.usart.syncbusy.read().ctrlb().bit_is_set() {}
+
+            sercom.usart.ctrla.write(|w| w.enable().set_bit());
+            // wait for sync of ENABLE
+            while sercom.usart.syncbusy.read().enable().bit_is_set() {}
+        }
+
+        Self {
+            rx,
+            tx,
+            sercom,
+        }
+    }
+
+    pub fn enable_tx_interrupt(&mut self) {
+        unsafe {
+            self.sercom.usart.intenset.write(|w| {
+                w.txc().set_bit()
+            });
+        }
+    }
+}
+
+impl Write<u8> for Uart {
+    type Error = ();
+
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        unsafe {
+            while self.sercom.usart.intflag.read().dre().bit_is_clear() {
+                // Wait fo DATA register to become empty
+            }
+
+            self.sercom.usart.data.write(|w| unsafe {
+                w.bits(word as u16)
+            });
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl Default<u8> for Uart {}

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -213,6 +213,26 @@ uart!([
         ),
 ]);
 
+#[cfg(feature = "samd21g18a")]
+uart!([
+    UART4:
+        (
+            Sercom4Pad2,
+            Sercom4Pad3,
+            SERCOM4,
+            sercom4_,
+            Sercom4CoreClock
+        ),
+    UART5:
+        (
+            Sercom5Pad2,
+            Sercom5Pad3,
+            SERCOM5,
+            sercom5_,
+            Sercom5CoreClock
+        ),
+]);
+
 fn calculate_baud_value(baudrate: u32, clk_freq: u32, n_samples: u8) -> u16 {
     let mut ratio: u64 = 0;
     let mut scale: u64 = 0;


### PR DESCRIPTION
This adds structs and corresponding `serial::{Read, Write}` impls for a UART on each sercom.

This works as is but needs some improvement to fully support all the features available on the samd21. Currently this is:

- Only asynchronous
- Only Arithmetic baud mode is supported
- Only 8N1
- Both TX/RX are always on

@wez 