### PR TITLE
pin nightly version to 2018-05-16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - nightly-2018-05-16
 cache: cargo
 script:
   - rustup target add thumbv6m-none-eabi

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ need to be using nightly rust.  You'll also need to install support for
 `thumbv6m-none-eabi`:
 
 ```bash
-$ rustup install nightly
-$ rustup default nightly
+$ rustup install nightly-2018-05-16
+$ rustup default nightly-2018-05-16
 $ rustup target add thumbv6m-none-eabi
 ```
 


### PR DESCRIPTION
Build is broken with latest nightly due to [panic_fmt removal]:

    ~/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-abort-0.1.1/src/lib.rs:25:1
       |
    25 | #[lang = "panic_fmt"]
       | ^^^^^^^^^^^^^^^^^^^^^ definition of unknown language item `panic_fmt`

Upgrading to newer panic-abort bumps into proc-macro2 issues described in japaric/rtfm-syntax#7 .

Stumbled onto this when investigating a [build failure] for #2.  Affected https://github.com/wez/atsamd21-rs/pull/1#issuecomment-398578462 too.

[panic_fmt removal]: https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875
[build failure]: https://travis-ci.org/wez/atsamd21-rs/builds/403798265#L570
