### PR TITLE
Allow configuring the external crystal for the clock source

### DIFF
--- a/arduino_mkrzero/examples/blinky_basic.rs
+++ b/arduino_mkrzero/examples/blinky_basic.rs
@@ -13,7 +13,7 @@ entry!(main);
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::new(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,

--- a/gemma_m0/examples/blinky_basic.rs
+++ b/gemma_m0/examples/blinky_basic.rs
@@ -18,7 +18,7 @@ entry!(main);
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::new(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -95,7 +95,12 @@ pub struct GenericClockController {
 impl GenericClockController {
     /// Reset the clock controller, configure the system to run
     /// at 48Mhz and reset various clock dividers.
-    pub fn new(gclk: GCLK, pm: &mut PM, sysctrl: &mut SYSCTRL, nvmctrl: &mut NVMCTRL) -> Self {
+    pub fn with_internal_32kosc(
+        gclk: GCLK,
+        pm: &mut PM,
+        sysctrl: &mut SYSCTRL,
+        nvmctrl: &mut NVMCTRL,
+    ) -> Self {
         let mut state = State { gclk };
 
         set_flash_to_half_auto_wait_state(nvmctrl);

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -7,7 +7,7 @@
 //! for the pin.   The pin configuration is reflected through the
 //! use of type states to make the interface (ideally, or at least practically)
 //! impossible to misuse.
-use target_device::port::{PINCFG0_, PMUX0_, DIRCLR, DIRSET, OUTCLR, OUTSET};
+use target_device::port::{DIRCLR, DIRSET, OUTCLR, OUTSET, PINCFG0_, PMUX0_};
 
 #[cfg(feature = "samd21g18a")]
 use target_device::port::{PINCFG1_, PMUX1_};
@@ -17,7 +17,7 @@ use hal::digital::OutputPin;
 use target_device::PORT;
 
 #[cfg(feature = "unproven")]
-use hal::digital::{InputPin, ToggleableOutputPin, StatefulOutputPin};
+use hal::digital::{InputPin, StatefulOutputPin, ToggleableOutputPin};
 
 /// The GpioExt trait allows splitting the PORT hardware into
 /// its constituent pin parts.

--- a/hal/src/sercom/i2c.rs
+++ b/hal/src/sercom/i2c.rs
@@ -4,7 +4,7 @@ use clock;
 use hal::blocking::i2c::{Read, Write, WriteRead};
 use sercom::pads::*;
 use target_device::sercom0::I2CM;
-use target_device::{SERCOM0, SERCOM1, SERCOM2, SERCOM3, PM};
+use target_device::{PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
 #[cfg(feature = "samd21g18a")]
 use target_device::{SERCOM4, SERCOM5};
 use time::Hertz;

--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -3,7 +3,7 @@ use hal::spi::{FullDuplex, Mode, Phase, Polarity};
 use nb;
 use sercom::pads::*;
 use target_device::sercom0::SPI;
-use target_device::{SERCOM0, SERCOM1, SERCOM2, SERCOM3, PM};
+use target_device::{PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
 #[cfg(feature = "samd21g18a")]
 use target_device::{SERCOM4, SERCOM5};
 use time::Hertz;

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -1,15 +1,15 @@
-use target_device::{NVIC, PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
-#[cfg(feature = "samd21g18a")]
-use target_device::{SERCOM4, SERCOM5};
-use target_device::Interrupt;
-use target_device::sercom0::USART;
 use clock;
-use hal::blocking::serial::{Write, write::Default};
+use core::fmt;
+use hal::blocking::serial::{write::Default, Write};
 use hal::serial;
 use nb;
 use sercom::pads::*;
+use target_device::sercom0::USART;
+use target_device::Interrupt;
+use target_device::{NVIC, PM, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
+#[cfg(feature = "samd21g18a")]
+use target_device::{SERCOM4, SERCOM5};
 use time::Hertz;
-use core::fmt;
 
 macro_rules! uart_pinout {
     ([$($Type:ident:
@@ -238,52 +238,16 @@ impl fmt::Write for $Type {
 }
 
 uart!([
-    UART0:
-        (
-            UART0Pinout,
-            SERCOM0,
-            sercom0_,
-            Sercom0CoreClock
-        ),
-    UART1:
-        (
-            UART1Pinout,
-            SERCOM1,
-            sercom1_,
-            Sercom1CoreClock
-        ),
-    UART2:
-        (
-            UART2Pinout,
-            SERCOM2,
-            sercom2_,
-            Sercom2CoreClock
-        ),
-    UART3:
-        (
-            UART3Pinout,
-            SERCOM3,
-            sercom3_,
-            Sercom3CoreClock
-        ),
+    UART0: (UART0Pinout, SERCOM0, sercom0_, Sercom0CoreClock),
+    UART1: (UART1Pinout, SERCOM1, sercom1_, Sercom1CoreClock),
+    UART2: (UART2Pinout, SERCOM2, sercom2_, Sercom2CoreClock),
+    UART3: (UART3Pinout, SERCOM3, sercom3_, Sercom3CoreClock),
 ]);
 
 #[cfg(feature = "samd21g18a")]
 uart!([
-    UART4:
-        (
-            UART4Pinout,
-            SERCOM4,
-            sercom4_,
-            Sercom4CoreClock
-        ),
-    UART5:
-        (
-            UART5Pinout,
-            SERCOM5,
-            sercom5_,
-            Sercom5CoreClock
-        ),
+    UART4: (UART4Pinout, SERCOM4, sercom4_, Sercom4CoreClock),
+    UART5: (UART5Pinout, SERCOM5, sercom5_, Sercom5CoreClock),
 ]);
 
 const SHIFT: u8 = 32;

--- a/hal/src/timer.rs
+++ b/hal/src/timer.rs
@@ -2,7 +2,7 @@
 use hal::timer::{CountDown, Periodic};
 use target_device::tc3::COUNT16;
 #[allow(unused)]
-use target_device::{TC3, TC4, TC5, PM};
+use target_device::{PM, TC3, TC4, TC5};
 
 use clock;
 use nb;

--- a/metro_m0/examples/blinky_basic.rs
+++ b/metro_m0/examples/blinky_basic.rs
@@ -23,7 +23,7 @@ entry!(main);
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_internal_32kosc(
+    let mut clocks = GenericClockController::with_external_32kosc(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,

--- a/metro_m0/examples/blinky_basic.rs
+++ b/metro_m0/examples/blinky_basic.rs
@@ -23,7 +23,7 @@ entry!(main);
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::new(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,

--- a/metro_m0/examples/blinky_rtfm.rs
+++ b/metro_m0/examples/blinky_rtfm.rs
@@ -68,7 +68,7 @@ fn idle() -> ! {
 }
 
 fn init(mut p: init::Peripherals) -> init::LateResources {
-    let mut clocks = GenericClockController::new(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         p.device.GCLK,
         &mut p.device.PM,
         &mut p.device.SYSCTRL,

--- a/metro_m0/examples/rando.rs
+++ b/metro_m0/examples/rando.rs
@@ -99,7 +99,7 @@ fn idle(_t: &mut Threshold, _r: idle::Resources) -> ! {
 fn init(mut p: init::Peripherals /* , r: init::Resources */) -> init::LateResources {
     let interval = 1.hz();
 
-    let mut clocks = GenericClockController::new(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         p.device.GCLK,
         &mut p.device.PM,
         &mut p.device.SYSCTRL,

--- a/samd21_mini/examples/serial.rs
+++ b/samd21_mini/examples/serial.rs
@@ -75,7 +75,7 @@ fn idle() -> ! {
 fn init(mut p: init::Peripherals) -> init::LateResources {
     let mut pins = hal::Pins::new(p.device.PORT);
 
-    let mut clocks = GenericClockController::new(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         p.device.GCLK,
         &mut p.device.PM,
         &mut p.device.SYSCTRL,


### PR DESCRIPTION
According to the datasheet, the internal 32khz osc is not suitable for USB compliance,
so it is desirable to use an external crystal when available.