### PR TITLE
Add very basic support for Adafruit's ItsyBitsy M0 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ There are a couple of crates provided by this repo:
 * [`gemma_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/) is a board support crate
   for the Adafruit Gemma M0 board.  Similar to the Metro M0 crate, it re-exports the
   `atsamd21-hal` crate functionality using more convenient names.
+* [`itsybitsy_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/) is a board support crate
+  for the Adafruit ItsyBitsy M0 board.  It re-exports the `atsamd21-hal` crate functionality
+  using more convenient names; for example, the IO pins are exported using the labels
+  printed on the board rather than the more abstract and harder to remember port and
+  pin numbers used by the underlying device.
 
 ## Building
 

--- a/boards/gemma_m0/README.md
+++ b/boards/gemma_m0/README.md
@@ -1,7 +1,7 @@
-# Adafruit Metro M0 Board Support Crate
+# Adafruit Gemma M0 Board Support Crate
 
-This crate provides a type-safe API for working with the [Adafruit Metro M0
-board](https://www.adafruit.com/product/3505).
+This crate provides a type-safe API for working with the [Adafruit Gemma M0
+board](https://www.adafruit.com/product/3501).
 
 ## Examples?
 

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -25,6 +25,8 @@ default-features = false
 
 [dev-dependencies]
 panic-abort = "~0.2"
+ssd1306 = "~0.2"
+embedded-graphics = "^0.4.0"
 
 [features]
 # ask the HAL to enable atsamd21g18a support

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "itsybitsy_m0"
+version = "0.1.0"
+authors = ["Ben Bergman <ben@benbergman.ca>"]
+description = "Board Support crate for the Adafruit ItsyBitsy M0"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/wez/atsamd21-rs"
+readme = "README.md"
+documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/"
+
+[dependencies]
+cortex-m = "~0.5"
+embedded-hal = "~0.2"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6"
+optional = true
+
+[dependencies.atsamd21-hal]
+path = "../../hal"
+version = "~0.2"
+default-features = false
+
+[dev-dependencies]
+panic-abort = "~0.2"
+
+[features]
+# ask the HAL to enable atsamd21g18a support
+default = ["rt", "atsamd21-hal/samd21g18a"]
+rt = ["cortex-m-rt", "atsamd21-hal/samd21g18a-rt"]
+unproven = ["atsamd21-hal/unproven"]
+use_semihosting = []

--- a/boards/itsybitsy_m0/README.md
+++ b/boards/itsybitsy_m0/README.md
@@ -1,0 +1,10 @@
+# Adafruit Metro M0 Board Support Crate
+
+This crate provides a type-safe API for working with the [Adafruit Metro M0
+board](https://www.adafruit.com/product/3505).
+
+## Examples?
+
+Check out the repository for examples:
+
+https://github.com/wez/atsamd21-rs/tree/master/boards/itsybitsy_m0/examples

--- a/boards/itsybitsy_m0/README.md
+++ b/boards/itsybitsy_m0/README.md
@@ -1,7 +1,7 @@
-# Adafruit Metro M0 Board Support Crate
+# Adafruit ItsyBitsy M0 Board Support Crate
 
-This crate provides a type-safe API for working with the [Adafruit Metro M0
-board](https://www.adafruit.com/product/3505).
+This crate provides a type-safe API for working with the [Adafruit ItsyBitsy M0
+board](https://www.adafruit.com/product/3727).
 
 ## Examples?
 

--- a/boards/itsybitsy_m0/build.rs
+++ b/boards/itsybitsy_m0/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/itsybitsy_m0/examples/blinky_basic.rs
+++ b/boards/itsybitsy_m0/examples/blinky_basic.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![no_main]
+
+extern crate itsybitsy_m0 as hal;
+extern crate panic_abort;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::{entry, CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    loop {
+        delay.delay_ms(200u8);
+        red_led.set_high();
+        delay.delay_ms(200u8);
+        red_led.set_low();
+    }
+}

--- a/boards/itsybitsy_m0/examples/i2c_ssd1306.rs
+++ b/boards/itsybitsy_m0/examples/i2c_ssd1306.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+
+extern crate itsybitsy_m0 as hal;
+extern crate panic_abort;
+
+extern crate embedded_graphics;
+extern crate ssd1306;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::{entry, CorePeripherals, Peripherals};
+use hal::time::KiloHertz;
+
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::{Circle, Line, Rect};
+use ssd1306::prelude::*;
+use ssd1306::Builder;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let i2c = hal::i2c_master(
+        &mut clocks,
+        KiloHertz(400),
+        peripherals.SERCOM3,
+        &mut peripherals.PM,
+        pins.sda,
+        pins.scl,
+        &mut pins.port,
+        );
+
+
+    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+
+    disp.init().unwrap();
+    disp.flush().unwrap();
+
+    disp.draw(
+        Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 16, 16 + 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+    disp.draw(
+        Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 8, 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+    disp.draw(
+        Line::new(Coord::new(8 + 16, 16 + 16), Coord::new(8 + 8, 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+
+    disp.draw(
+        Rect::new(Coord::new(48, 16), Coord::new(48 + 16, 16 + 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+
+    disp.draw(
+        Circle::new(Coord::new(96, 16 + 8), 8)
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+
+    disp.flush().unwrap();
+
+
+
+    loop {
+        delay.delay_ms(200u8);
+        red_led.set_high();
+        delay.delay_ms(200u8);
+        red_led.set_low();
+    }
+}

--- a/boards/itsybitsy_m0/examples/spi_ssd1306.rs
+++ b/boards/itsybitsy_m0/examples/spi_ssd1306.rs
@@ -1,0 +1,95 @@
+#![no_std]
+#![no_main]
+
+extern crate itsybitsy_m0 as hal;
+extern crate panic_abort;
+
+extern crate embedded_graphics;
+extern crate ssd1306;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::{entry, CorePeripherals, Peripherals};
+use hal::time::MegaHertz;
+
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::{Circle, Line, Rect};
+use ssd1306::prelude::*;
+use ssd1306::Builder;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let spi = hal::spi_master(
+        &mut clocks,
+        MegaHertz(10),
+        peripherals.SERCOM4,
+        &mut peripherals.PM,
+        pins.sck,
+        pins.mosi,
+        pins.miso,
+        &mut pins.port,
+        );
+
+
+
+    let dc = pins.d9.into_open_drain_output(&mut pins.port);
+    let mut rst = pins.d7.into_open_drain_output(&mut pins.port);
+
+    let mut disp: GraphicsMode<_> = Builder::new().connect_spi(spi, dc).into();
+
+    disp.reset(&mut rst, &mut delay);
+    disp.init().unwrap();
+    disp.flush().unwrap();
+
+    disp.draw(
+        Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 16, 16 + 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+    disp.draw(
+        Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 8, 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+    disp.draw(
+        Line::new(Coord::new(8 + 16, 16 + 16), Coord::new(8 + 8, 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+
+    disp.draw(
+        Rect::new(Coord::new(48, 16), Coord::new(48 + 16, 16 + 16))
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+
+    disp.draw(
+        Circle::new(Coord::new(96, 16 + 8), 8)
+        .with_stroke(Some(1u8.into()))
+        .into_iter(),
+        );
+
+    disp.flush().unwrap();
+
+
+
+    loop {
+        delay.delay_ms(200u8);
+        red_led.set_high();
+        delay.delay_ms(200u8);
+        red_led.set_low();
+    }
+}

--- a/boards/itsybitsy_m0/memory.x
+++ b/boards/itsybitsy_m0/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* Leave 8k for the default bootloader on the ItsyBitsy M0 */
+  FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
+

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -20,7 +20,24 @@ define_pins!(
     struct Pins,
     target_device: atsamd21g18a,
 
+    /// Analog pin 0.  Can act as a true analog output
+    /// as it has a DAC (which is not currently supported
+    /// by this hal) as well as input.
+    pin a0 = a2,
+    /// Analog Pin 1
+    pin a1 = b8,
+    /// Analog Pin 2
+    pin a2 = b9,
+    /// Analog Pin 3
+    pin a3 = a4,
+    /// Analog Pin 4
+    pin a4 = a5,
+    /// Analog Pin 5
+    pin a5 = b2,
+
+    /// Pin 0, rx
     pin d0 = a11,
+    /// Pin 1, tx
     pin d1 = a10,
     pin d2 = a14,
     pin d3 = a9,
@@ -33,27 +50,41 @@ define_pins!(
     pin d10 = a18,
     pin d11 = a16,
     pin d12 = a19,
+    /// Digital pin number 13, which is also attached to
+    /// the red LED.  PWM capable.
     pin d13 = a17,
 
-    pin a0 = a2,
-    pin a1 = b8,
-    pin a2 = b9,
-    pin a3 = a4,
-    pin a4 = a5,
-    pin a5 = b2,
-
+    /// The SPI MOSI attached the to 2x3 header
     pin mosi = b10,
+    /// The SPI MISO attached the to 2x3 header
     pin miso = a12,
+    /// The SPI SCK attached the to 2x3 header
     pin sck = b11,
 
+    /// The MOSI pin attached to the on-board SPI flash
     pin flash_mosi = b22,
+    /// The MISO pin attached to the on-board SPI flash
     pin flash_miso = b3,
+    /// The SCK pin attached to the on-board SPI flash
     pin flash_sck = b23,
+    /// The CS pin attached to the on-board SPI flash
     pin flash_cs = a27,
 
+    /// The I2C clock
     pin scl = a23,
+    /// The I2C data line
     pin sda = a22,
+
+    /// The DotStar clock
+    pin dotstar_ci = a0,
+    /// The DotStar data line
+    pin dotstar_di = a1,
 
     pin swdio = a31,
     pin swdclk = a30,
+
+    /// The USB D- pad
+    pin usb_dm = a24,
+    /// The USB D+ pad
+    pin usb_dp = a25,
 );

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![recursion_limit="1024"]
+
+extern crate atsamd21_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+pub use hal::atsamd21g18a::*;
+use hal::prelude::*;
+pub use hal::*;
+
+use gpio::{Floating, Input, Port};
+
+define_pins!(
+    /// Maps the pins to their arduino names and
+    /// the numbers printed on the board.
+    struct Pins,
+    target_device: atsamd21g18a,
+
+    pin d0 = a11,
+    pin d1 = a10,
+    pin d2 = a14,
+    pin d3 = a9,
+    pin d4 = a8,
+    pin d5 = a15,
+    pin d6 = a20,
+    pin d7 = a21,
+    pin d8 = a6,
+    pin d9 = a7,
+    pin d10 = a18,
+    pin d11 = a16,
+    pin d12 = a19,
+    pin d13 = a17,
+
+    pin a0 = a2,
+    pin a1 = b8,
+    pin a2 = b9,
+    pin a3 = a4,
+    pin a4 = a5,
+    pin a5 = b2,
+
+    pin mosi = b10,
+    pin miso = a12,
+    pin sck = b11,
+
+    pin flash_mosi = b22,
+    pin flash_miso = b3,
+    pin flash_sck = b23,
+    pin flash_cs = a27,
+
+    pin scl = a23,
+    pin sda = a22,
+
+    pin swdio = a31,
+    pin swdclk = a30,
+);

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -46,9 +46,7 @@ define_pins!(
     pin d3 = a9,
     pin d4 = a8,
     pin d5 = a15,
-    pin d6 = a20,
     pin d7 = a21,
-    pin d8 = a6,
     pin d9 = a7,
     pin d10 = a18,
     pin d11 = a16,
@@ -57,11 +55,11 @@ define_pins!(
     /// the red LED.  PWM capable.
     pin d13 = a17,
 
-    /// The SPI MOSI attached the to 2x3 header
+    /// The SPI MOSI
     pin mosi = b10,
-    /// The SPI MISO attached the to 2x3 header
+    /// The SPI MISO
     pin miso = a12,
-    /// The SPI SCK attached the to 2x3 header
+    /// The SPI SCK
     pin sck = b11,
 
     /// The MOSI pin attached to the on-board SPI flash

--- a/build-all.sh
+++ b/build-all.sh
@@ -8,5 +8,6 @@ set -xe
 
 cargo build --manifest-path boards/metro_m0/Cargo.toml --example blinky_basic
 cargo build --manifest-path boards/gemma_m0/Cargo.toml --examples
+cargo build --manifest-path boards/itsybitsy_m0/Cargo.toml --examples
 cargo build --manifest-path boards/samd21_mini/Cargo.toml --examples
 cargo build --manifest-path boards/arduino_mkrzero/Cargo.toml --examples

--- a/build-docs.py
+++ b/build-docs.py
@@ -11,7 +11,7 @@ import argparse
 # emit misleading docs.
 crates_by_pac = {
     'atsamd21e18a': ['gemma_m0'],
-    'atsamd21g18a': ['metro_m0', 'samd21_mini', 'arduino_mkrzero']
+    'atsamd21g18a': ['metro_m0', 'samd21_mini', 'arduino_mkrzero', 'itsybitsy_m0']
 }
 
 def generate_docs():


### PR DESCRIPTION
I've added basic support for Adafruit's ItsyBitsy M0 board based on the schematic on their website. I have not tested all I/O yet nor have I added all the other fancy stuff like the Metro M0 board has (I started with the Gemma M0 as I had one of those and it was simpler). I have tested blink though and wanted to post at least a work in progress. I'll try to add more as I find the time.

Edit: I copied over the SPI, I2C, and USB helper functions from the `metro_m0` crate and tested them with some SSD1306 displays I had lying around (included in examples in PR).