### PR TITLE
Fix builds due to (I assume) feature being enabled by default in nightly

### DIFF
--- a/boards/samd21_mini/examples/serial.rs
+++ b/boards/samd21_mini/examples/serial.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_gen)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
I noticed that all the current PRs are failing builds. It looks like the feature flag being used was removed from nightly. I just removed the offending feature flag and everything seems to build fine, though I don't have a `samd21_mini` board to test the serial example.

The error message from Travis:

```
error[E0557]: feature has been removed
 --> examples/serial.rs:1:12
  |
1 | #![feature(proc_macro_gen)]
  |            ^^^^^^^^^^^^^^
  |
note: subsumed by `#![feature(proc_macro_hygiene)]`
 --> examples/serial.rs:1:12
  |
1 | #![feature(proc_macro_gen)]
  |            ^^^^^^^^^^^^^^
                                                                                
error: aborting due to previous error
```